### PR TITLE
Set CHROME_VERSION_EXTRA

### DIFF
--- a/edge.sh
+++ b/edge.sh
@@ -40,6 +40,7 @@ fi
 # $XDG_DATA_DIRS, but Chrome's own loading of course does not follow that.
 # Therefore, we manually set the XCursor path to follow $XDG_DATA_DIRS here.
 export XCURSOR_PATH=$(echo "$XDG_DATA_DIRS" | sed 's,\(:\|$\),/icons\1,g')
+export CHROME_VERSION_EXTRA=dev
 export CHROME_WRAPPER=$(readlink -f "$0")
 export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
 export ZYPAK_SANDBOX_FILENAME=msedge-sandbox


### PR DESCRIPTION
Edge passes the value of this to the server when getting the list of
sites to fake user agents for, so leaving it empty would result in an
empty site list, thus causing random instances of breakage (e.g. Netflix
would try to use PlayReady rather than Widevine).

Closes https://github.com/flathub/com.microsoft.Edge/issues/8