### PR TITLE
Downgrade libsecret to 0.19.1

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -28,7 +28,7 @@ finish-args:
   - --own-name=org.mpris.MediaPlayer2.edge.*
   - --filesystem=xdg-download
 modules:
-  - shared-modules/libsecret/libsecret.json
+  - libsecret.json
 
   - name: libcups
     make-args: [libs]

--- a/libsecret.json
+++ b/libsecret.json
@@ -1,0 +1,23 @@
+{
+  "name": "libsecret",
+  "buildsystem": "meson",
+  "config-opts": [
+    "-Dmanpage=false",
+    "-Dvapi=false",
+    "-Dgtk_doc=false"
+  ],
+  "cleanup": [
+    "/bin",
+    "/include",
+    "/lib/pkgconfig",
+    "/share/gir-1.0", 
+    "/share/man"
+  ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://download.gnome.org/sources/libsecret/0.19/libsecret-0.19.1.tar.xz", 
+      "sha256": "8583e10179456ae2c83075d95455f156dc08db6278b32bf4bd61819335a30e3a"
+    }
+  ]
+}


### PR DESCRIPTION
Based on flathub/com.google.Chrome#40 by @andrunko.

> libsecret > 0.19.1 have an issue where passwords stored cannot be retrieved when running inside flatpak sandbox - https://gitlab.gnome.org/GNOME/libsecret/-/issues/49.
> Let's temporarily revert to a known working version until the issue is solved.