### PR TITLE
edge.sh: read flags from edge-flags.conf instead of chrome-flags.conf

### DIFF
--- a/edge.sh
+++ b/edge.sh
@@ -27,9 +27,9 @@ if [[ ! -f "$mimic_stamp" ]] && ! zypak-helper spawn-strategy-test; then
   touch "$mimic_stamp"
 fi
 
-if [[ -f "$XDG_CONFIG_HOME/chrome-flags.conf" ]]; then
+if [[ -f "$XDG_CONFIG_HOME/edge-flags.conf" ]]; then
   IFS=$'\n'
-  flags=($(grep -v '^#' "$XDG_CONFIG_HOME/chrome-flags.conf"))
+  flags=($(grep -v '^#' "$XDG_CONFIG_HOME/edge-flags.conf"))
   unset IFS
 
   set -- "${flags[@]}" "$@"


### PR DESCRIPTION
Maybe nitpicking, though I think that the conf filename should reflect that we are running Edge.  
You can tag it as a branding issue and as such this is probably an expected change if this package will be adopted officially by Redmond. Better do this early and affect fewer users.