### PR TITLE
Extract the binary deb release with bsdtar

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/sh
-ar x edge.deb data.tar.xz
+
+set -e
+
+bsdtar -Oxf edge.deb 'data.tar*' |
+  bsdtar -xf - \
+    --strip-components=4 \
+    --exclude='./opt/microsoft/msedge-dev/nacl*' \
+    ./opt/microsoft/msedge-dev
 rm edge.deb
-tar -xf data.tar.xz --strip-components=4 ./opt/microsoft/msedge-dev
-rm data.tar.xz nacl*
-cp /app/bin/stub_sandbox msedge-sandbox
+
+install -Dm755 /app/bin/stub_sandbox msedge-sandbox

--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -98,10 +98,6 @@ modules:
       - install -Dm 644 -t /app/share/applications com.microsoft.Edge.desktop
       - install -Dm 644 -t /app/share/metainfo com.microsoft.Edge.metainfo.xml
       - install -Dm 644 com.microsoft.Edge-256.png /app/share/icons/hicolor/256x256/apps/com.microsoft.Edge.png
-
-      # For extra-data to be able to extract the .deb
-      - install -Dm 755 /{usr,app}/bin/ar
-      - cp /usr/lib/$(gcc --print-multiarch)/libbfd-*.so /app/lib
     sources:
       - type: extra-data
         # From https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-dev


### PR DESCRIPTION
Changes and benefits:

* Switch from GNU ar to BSD tar, which is already in the Platform runtime.
* Pipe the deb package extraction to avoid unnecessary disk writes.
* Use a wildcard so the extraction won't fail if the chosen compression type changed.
* Make sure that apply_extra exits with an error if something went wrong during the extraction so
  we won't end with a broken installation. Better no installation than a broken one.