### PR TITLE
Fix startup issue with 92.0.902.9-1

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -106,7 +106,6 @@ modules:
         url: https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-beta/microsoft-edge-beta_92.0.902.9-1_amd64.deb
         sha256: fdd267418b93e0df9accbe1e8b8489f9b824f117edd7bd2ce22cf9a16b396acd
         filename: edge.deb
-        strip-components: 0
         x-checker-data:
           type: debian-repo
           package-name: microsoft-edge-beta

--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -78,8 +78,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/refi64/zypak
-        tag: v2021.02
-        commit: ae8b0423588479d8403c192feb630c582656bee6
+        #tag: v2021.02
+        commit: 89dd114427a114028f249ed9b2824d083f459eb5
   - name: flextop
     buildsystem: meson
     sources:


### PR DESCRIPTION
Bump zypak to refi64/zypak@89dd114 to have 92.0.902.9-1 set up the sandbox correctly and not crash.  
Use this chance to also remove strip-components from extra-data source type which doesn't have this property.