### PR TITLE
zyapk: build the v2021.06 release

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -78,7 +78,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/refi64/zypak
-        #tag: v2021.02
+        tag: v2021.06
         commit: 89dd114427a114028f249ed9b2824d083f459eb5
   - name: flextop
     buildsystem: meson


### PR DESCRIPTION
No actual change in the packaged zypak because the tagged release is on the same commit.

Edge was updated today so use this opportunity to make the change now, hopefully avoiding multiple updates on users' machines.