### PR TITLE
Add GTK4 IM modules

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -45,7 +45,7 @@ modules:
         url: https://github.com/OpenPrinting/cups.git
         tag: v2.3.3op2
         commit: 3b566f73587ffa8ad9690f2399efc4508b3a9016
-  - name: gtk-cups-backend
+  - name: gtk3-cups-backend
     buildsystem: meson
     make-args: [modules/printbackends/libprintbackend-cups.so]
     no-make-install: true
@@ -59,10 +59,14 @@ modules:
        # From https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/master/files/gtk3-werror.patch
       - type: patch
         path: gtk3-werror.patch
+
+  - gtkimm/gtkimm.yaml
+
   - name: gtk-settings
     buildsystem: simple
     build-commands:
       - install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini
+      - install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-4.0/settings.ini
     sources:
       - type: file
         path: gtk-settings.ini

--- a/gtkimm/fcitx5-gtk.yaml
+++ b/gtkimm/fcitx5-gtk.yaml
@@ -1,0 +1,32 @@
+name: fcitx5-gtk
+buildsystem: cmake-ninja
+config-opts:
+  - -DGTK3_IM_MODULEDIR=${FLATPAK_DEST}/lib/gtkmodules/3.0.0/immodules
+  - -DGTK4_IM_MODULEDIR=${FLATPAK_DEST}/lib/gtkmodules/4.0.0/immodules
+  - -DENABLE_GIR=OFF
+  - -DENABLE_GTK2_IM_MODULE=OFF
+  - -DENABLE_GTK3_IM_MODULE=ON
+  - -DENABLE_GTK4_IM_MODULE=ON
+  - -DENABLE_SNOOPER=ON
+sources:
+  - type: archive
+    url: https://github.com/fcitx/fcitx5-gtk/archive/5.0.10/fcitx5-gtk-5.0.10.tar.gz
+    sha256: 70d189d58d78ebf298162f44f506d68a2489c092ad938ed34429c272066e2eef
+    x-checker-data:
+      type: anitya
+      project-id: 138235
+      stable-only: true
+      url-template: https://github.com/fcitx/fcitx5-gtk/archive/$version/fcitx5-gtk-$version.tar.gz
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+modules:
+  - name: extra-cmake-modules
+    buildsystem: cmake
+    sources:
+      - type: archive
+        url: https://download.kde.org/stable/frameworks/5.89/extra-cmake-modules-5.89.0.tar.xz
+        sha256: 3dd7229a225923b8570a333ee6e4a07b0f5f700ea9538fdeb22cc3cbba69f02f
+    cleanup:
+      - '*'

--- a/gtkimm/gtk4.yaml
+++ b/gtkimm/gtk4.yaml
@@ -1,0 +1,110 @@
+name: gtk4
+buildsystem: meson
+builddir: true
+build-options:
+  cflags: -DG_DISABLE_CAST_CHECKS
+config-opts:
+  - -Dx11-backend=true
+  - -Dwayland-backend=true
+  - -Dbroadway-backend=false
+  - -Dmedia-ffmpeg=disabled
+  - -Dmedia-gstreamer=disabled
+  - -Dprint-cups=enabled
+  - -Dcloudproviders=disabled
+  - -Dsysprof=disabled
+  - -Dtracker=disabled
+  - -Dcolord=disabled
+  - -Dgtk_doc=false
+  - -Dman-pages=false
+  - -Ddebug=false
+  - -Dintrospection=disabled
+  - -Ddemos=false
+  - -Dbuild-examples=false
+  - -Dbuild-tests=false
+sources:
+  - type: archive
+    url: https://download.gnome.org/sources/gtk/4.4/gtk-4.4.1.tar.xz
+    sha256: 0faada983dc6b0bc409cb34c1713c1f3267e67c093f86b1e3b17db6100a3ddf4
+    x-checker-data:
+      type: gnome
+      name: gtk
+      versions:
+        # newer releases require updated libpango
+        <: 4.6.0
+      stable-only: true
+  - type: shell
+    commands:
+      - sed '/^printbackends_subdir/ s/gtk-4\.0/gtkmodules/' -i modules/printbackends/meson.build
+cleanup:
+  - /bin
+  - /include
+  - /lib/pkgconfig
+  - /share/gettext
+  - /share/gtk-4.0/gtk4builder.rng
+  - /share/gtk-4.0/valgrind
+modules:
+  - name: graphene
+    buildsystem: meson
+    config-opts:
+      - -Dintrospection=disabled
+      - -Dtests=false
+      - -Dinstalled_tests=false
+    sources:
+      - type: archive
+        url: https://github.com/ebassi/graphene/releases/download/1.10.6/graphene-1.10.6.tar.xz
+        sha256: 80ae57723e4608e6875626a88aaa6f56dd25df75024bd16e9d77e718c3560b25
+        x-checker-data:
+          type: anitya
+          project-id: 12758
+          stable-only: true
+          url-template: https://github.com/ebassi/graphene/releases/download/$version/graphene-$version.tar.xz
+    cleanup:
+      - /include
+      - /lib/graphene-1.0
+      - /lib/pkgconfig
+  - name: hicolor-icon-theme
+    sources:
+      - type: archive
+        url: https://icon-theme.freedesktop.org/releases/hicolor-icon-theme-0.17.tar.xz
+        sha256: 317484352271d18cbbcfac3868eab798d67fff1b8402e740baa6ff41d588a9d8
+        x-checker-data:
+          type: anitya
+          project-id: 1316
+          stable-only: true
+          url-template: https://icon-theme.freedesktop.org/releases/hicolor-icon-theme-$version.tar.xz
+    cleanup:
+      - '*'
+  - name: sassc
+    sources:
+      - type: archive
+        url: https://github.com/sass/sassc/archive/3.6.2/sassc-3.6.2.tar.gz
+        sha256: 608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03
+        x-checker-data:
+          type: anitya
+          project-id: 12485
+          stable-only: true
+          url-template: https://github.com/sass/sassc/archive/$version/sassc-$version.tar.gz
+      - type: shell
+        commands:
+          - autoreconf -fiv
+    cleanup:
+      - '*'
+    modules:
+      - name: libsass
+        config-opts:
+          - --enable-shared
+          - --disable-static
+        sources:
+          - type: archive
+            url: https://github.com/sass/libsass/archive/3.6.5/libsass-3.6.5.tar.gz
+            sha256: 89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582
+            x-checker-data:
+              type: anitya
+              project-id: 11766
+              stable-only: true
+              url-template: https://github.com/sass/libsass/archive/$version/libsass-$version.tar.gz
+          - type: shell
+            commands:
+              - autoreconf -fiv
+        cleanup:
+          - '*'

--- a/gtkimm/gtkimm.yaml
+++ b/gtkimm/gtkimm.yaml
@@ -1,0 +1,9 @@
+name: gtkimm
+buildsystem: simple
+build-commands:
+  - gio-querymodules ${FLATPAK_DEST}/lib/gtkmodules/4.0.0/immodules
+  - gtk-query-immodules-3.0 ${FLATPAK_DEST}/lib/gtkmodules/3.0.0/immodules/*.so > ${FLATPAK_DEST}/lib/gtkmodules/3.0.0/immodules/immodules.cache
+modules:
+  - gtk4.yaml
+  - fcitx5-gtk.yaml
+  - ibus-gtk.yaml

--- a/gtkimm/ibus-gtk.yaml
+++ b/gtkimm/ibus-gtk.yaml
@@ -1,0 +1,44 @@
+name: ibus-gtk
+config-opts:
+  - --disable-tests
+  - --disable-gtk2
+  - --enable-gtk3
+  - --enable-gtk4
+  - --disable-xim
+  - --disable-wayland
+  - --disable-appindicator
+  - --disable-introspection
+  - --disable-gtk-doc
+  - --disable-memconf
+  - --disable-dconf
+  - --disable-python2
+  - --disable-setup
+  - --with-python=python3
+  - --disable-python-library
+  - --enable-key-snooper
+  - --enable-surrounding-text
+  - --disable-ui
+  - --disable-engine
+  - --disable-emoji-dict
+  - --disable-unicode-dict
+  - --disable-vala
+  - --with-gtk3-im-module-dir=${FLATPAK_DEST}/lib/gtkmodules/3.0.0/immodules
+  - --with-gtk4-im-module-dir=${FLATPAK_DEST}/lib/gtkmodules/4.0.0/immodules
+sources:
+  - type: archive
+    url: https://github.com/ibus/ibus/releases/download/1.5.25/ibus-1.5.25.tar.gz
+    sha256: dea4f663c485267cc3313e40a0bc89b977c397e19644f8ab41df0e6eaec34330
+    x-checker-data:
+      type: anitya
+      project-id: 1352
+      stable-only: true
+      url-template: https://github.com/ibus/ibus/releases/download/$version/ibus-$version.tar.gz
+  - type: shell
+    commands:
+      - sed '/^AM_CONDITIONAL.*ENABLE_DAEMON/ s/true/false/' -i configure.ac
+      - sed '/^SUBDIRS/,/$(NULL)/ s/data\|docs\|ibus\|portal\|tools\|util//' -i Makefile.am
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share
+  - '*.la'


### PR DESCRIPTION
I'm not sure if we really want to build and package GTK4, so this should be discussed further.  
I opened an [issue about this in the Chrome packaging repo](https://github.com/flathub/com.google.Chrome/issues/106).

Anyway, this adds the GTK4 IM modules to have Fcitx5 and IBus working with Ozone Wayland.  
Updated GTK3 IM modules were also added.

Users need to start the browser with the `--gtk-version=4` flag.

Note that Fcitx5 has an IBus backend, and the IBus IM module has popup working, so it's preferable to use the IBus IM module with the Fcitx5 daemon, or just use the IBus daemon.  
If you want to stick with Fcitx5 daemon, then set an environment override `GTK_IM_MODULE=IBus` for Edge in order to use the IBus IM module.