### PR TITLE
DRAFT: Enabling Wayland Support

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -16,7 +16,7 @@ finish-args:
   - --share=network
   - --socket=cups
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --require-version=1.8.2
   - --system-talk-name=org.freedesktop.UPower


### PR DESCRIPTION
Do not merge this!

This code change is needed for proper Wayland support.
Currently, it resolves in a crash but after the Wayland support is full in Microsoft Edge, this needs to merge.