### PR TITLE
CI: Add update workflow

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,25 @@
+name: Check for updates
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch: {}
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [ master, beta ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork com.microsoft.Edge.yaml

--- a/flathub.json
+++ b/flathub.json
@@ -2,5 +2,6 @@
   "only-arches": [
     "x86_64"
   ],
-  "automerge-flathubbot-prs": true
+  "automerge-flathubbot-prs": true,
+  "disable-external-data-checker": true
 }


### PR DESCRIPTION
Adding a GitHub workflow to run flapak-external-data-checker every ~~30 minutes~~ hour, which should get us similar behavior
as the current checks run by flathubbot.

This only needs to be in the default branch.
This covers both master and beta branches, so if the beta branch is kept alive, and a new beta app is not submitted,
then we probably want this in.  
**edit: And if it's not clear, if the beta branch is abandoned, then there's no reason to merge this.**
Collaborators can trigger the workflow manually, though it's not really needed with the current cron schedule.
Auto-merging open PRs is implemented in f-e-d-c's code, so it should work with this workflow and the currently
configured `automerge-flathubbot-prs` property.

This is pretty much the same the example workflow in https://github.com/flathub/flatpak-external-data-checker,
but with the added beta branch and shorter cron intervals