### PR TITLE
fix(com.microsoft.Edge): fix various portions of the image

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -17,6 +17,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=cups
+  - --socket=pcsc # FIDO2
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland
@@ -24,14 +25,24 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=org.freedesktop.FileManager1
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.kwalletd5
   - --talk-name=org.gnome.SessionManager
+  - --talk-name=org.gnome.Mutter.IdleMonitor.*
   - --talk-name=com.canonical.AppMenu.Registrar
   - --system-talk-name=org.freedesktop.Avahi
   - --filesystem=/run/.heim_org.h5l.kcm-socket
+  - --filesystem=host-etc
+  - --filesystem=home/.local/share/applications:create
+  - --filesystem=home/.local/share/icons:create
   - --filesystem=xdg-run/pipewire-0
   - --own-name=org.mpris.MediaPlayer2.edge.*
+  - --filesystem=xdg-documents
   - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-desktop
   - --persist=.pki
 modules:
   - name: dconf
@@ -100,10 +111,8 @@ modules:
         commands:
           - 'echo "Stub sandbox ignoring command: $@"'
           - exit 1
-      - type: script
-        dest-filename: edge.sh
-        commands:
-          - exec cobalt "$@"
+      - type: file
+        path: edge.sh
       - type: file
         path: cobalt.ini
       - type: file

--- a/edge.sh
+++ b/edge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+# Merge the policies with the host ones.
+policy_root=/etc/opt/edge/policies
+
+for policy_type in managed recommended enrollment; do
+  policy_dir="$policy_root/$policy_type"
+  mkdir -p "$policy_dir"
+
+  if [[ "$policy_type" == 'managed' ]]; then
+    ln -sf /app/share/flatpak-edge/flatpak_policy.json "$policy_dir"
+  fi
+
+  if [[ -d "/run/host/$policy_root/$policy_type" ]]; then
+    find "/run/host/$policy_root/$policy_type" -type f -name '*' \
+      -maxdepth 1 -name '*.json' -type f \
+      -exec ln -sf '{}' "$policy_root/$policy_type" \;
+  fi
+done
+
+exec cobalt "$@"

--- a/flatpak_policy.json
+++ b/flatpak_policy.json
@@ -1,3 +1,4 @@
 {
-  "DefaultBrowserSettingEnabled": false
+  "DefaultBrowserSettingEnabled": false,
+  "SmartScreenEnabled": false
 }


### PR DESCRIPTION
This PR syncs certain flags from other Chromium based browser images (mainly `com.brave.Browser`) for fixing KDE integration (hopefully including https://github.com/flathub/com.microsoft.Edge/issues/202) for UI and secrets (like `kwalletd5`) and enabling `pcsc` access for FIDO2 security keys, regular ISO 7816 smartcards etc.

This PR also fixes abrupt crashes on startup (https://github.com/flathub/com.microsoft.Edge/issues/238, https://github.com/flathub/com.microsoft.Edge/issues/235#issuecomment-1361928425 and hopefully https://github.com/flathub/com.microsoft.Edge/issues/242), which is caused by Microsoft SmartScreen being enabled by default and SmartScreen `SIGABRT`ing on startup in systems running latest kernels (see https://aur.archlinux.org/packages/microsoft-edge-stable-bin#comment-893592). By setting `SmartScreenEnabled` to false from the browser policies; Edge can now start up without crashing.

Tested on openSUSE Tumbleweed 20230117, running kernel 6.1.6-1-default and KDE Plasma 5.26.5.

- Closes https://github.com/flathub/com.microsoft.Edge/issues/202
- Closes https://github.com/flathub/com.microsoft.Edge/issues/238
- Closes https://github.com/flathub/com.microsoft.Edge/issues/235
- Closes https://github.com/flathub/com.microsoft.Edge/issues/242