### PR TITLE
Fix various portions

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -17,6 +17,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=cups
+  - --socket=pcsc # FIDO2
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland
@@ -24,14 +25,24 @@ finish-args:
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=org.freedesktop.FileManager1
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.kwalletd5
   - --talk-name=org.gnome.SessionManager
+  - --talk-name=org.gnome.Mutter.IdleMonitor.*
   - --talk-name=com.canonical.AppMenu.Registrar
   - --system-talk-name=org.freedesktop.Avahi
   - --filesystem=/run/.heim_org.h5l.kcm-socket
+  - --filesystem=host-etc
+  - --filesystem=home/.local/share/applications:create
+  - --filesystem=home/.local/share/icons:create
   - --filesystem=xdg-run/pipewire-0
   - --own-name=org.mpris.MediaPlayer2.edge.*
+  - --filesystem=xdg-documents
   - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-desktop
   - --persist=.pki
 modules:
   - name: dconf
@@ -100,10 +111,8 @@ modules:
         commands:
           - 'echo "Stub sandbox ignoring command: $@"'
           - exit 1
-      - type: script
-        dest-filename: edge.sh
-        commands:
-          - exec cobalt "$@"
+      - type: file
+        path: edge.sh
       - type: file
         path: cobalt.ini
       - type: file

--- a/edge.sh
+++ b/edge.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+# Merge the policies with the host ones.
+policy_root=/etc/opt/edge/policies
+
+for policy_type in managed recommended enrollment; do
+  policy_dir="$policy_root/$policy_type"
+  mkdir -p "$policy_dir"
+
+  if [[ "$policy_type" == 'managed' ]]; then
+    ln -sf /app/share/flatpak-edge/flatpak_policy.json "$policy_dir"
+  fi
+
+  if [[ -d "/run/host/$policy_root/$policy_type" ]]; then
+    find "/run/host/$policy_root/$policy_type" -type f -name '*' \
+      -maxdepth 1 -name '*.json' -type f \
+      -exec ln -sf '{}' "$policy_root/$policy_type" \;
+  fi
+done
+
+exec cobalt "$@"

--- a/flatpak_policy.json
+++ b/flatpak_policy.json
@@ -1,3 +1,4 @@
 {
-  "DefaultBrowserSettingEnabled": false
+  "DefaultBrowserSettingEnabled": false,
+  "SmartScreenEnabled": false
 }


### PR DESCRIPTION
This commit syncs certain flags for other Chromium based browser images (mainly com.brave.Browser) for fixing KDE integration for UI and secrets (like kwalletd5) and enabling pcsc access for FIDO2 security keys, regular ISO 7816 smartcards etc.

This commit also fixes abrupt crashes on startup, which is caused by Microsoft SmartScreen being enabled by default and SmartScreen SIGABRT'ing in startup on systems running latest kernels. By setting SmartScreenEnabled to false from the browser policies; Edge can now start up without crashing.

Co-authored-by: Hari Rana <theevilskeleton@riseup.net>