### PR TITLE
pcsc-lite and opensc for edge stable

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -70,6 +70,30 @@ modules:
       - type: patch
         path: dconf-override.patch
 
+  - name: pcsc-lite
+    config-opts:
+      - --disable-libudev
+      - --disable-libsystemd
+      - --without-systemdsystemunitdir
+      - --disable-serial
+      - --disable-usb
+      - --disable-documentation
+    post-install:
+      - rm /app/sbin/pcscd
+      - rmdir /app/sbin || true
+    sources:
+      - type: archive
+        url: https://github.com/LudovicRousseau/PCSC/archive/refs/tags/1.9.9.tar.gz
+        sha256: 856a1daed9a5ae1ac265c75ce9f81743e66a972e5be5a1d3a2196ed23f75ea26
+
+  - name: opensc
+    cleanup:
+      - /share/applications/org.opensc.notify.desktop
+    sources:
+      - type: archive
+        url: https://github.com/OpenSC/OpenSC/releases/download/0.23.0/opensc-0.23.0.tar.gz
+        sha256: a4844a6ea03a522ecf35e49659716dacb6be03f7c010a1a583aaf3eb915ed2e0
+
   - name: zypak
     sources:
       - type: git

--- a/edge.sh
+++ b/edge.sh
@@ -18,4 +18,13 @@ for policy_type in managed recommended enrollment; do
   fi
 done
 
+# Add opensc lib to nss pkcs11.txt file
+pkcs11_txt="${HOME}/.pki/nssdb/pkcs11.txt"
+
+if [[ -e "${pkcs11_txt}" ]] && ! grep -qF opensc-pkcs11.so "${pkcs11_txt}"; then
+  [[ $(tail -n 1 "${pkcs11_txt}") == '' ]] || printf '\n' >> "${pkcs11_txt}"
+  printf 'library=/app/lib/onepin-opensc-pkcs11.so\nname=opensc\n' \
+    >> "${pkcs11_txt}"
+fi
+
 exec cobalt "$@"


### PR DESCRIPTION
This PR adds pcsc-lite and opensc to the Edge stable flatpak to enable use of PKCS#11 security tokens (IE: smart cards). See the edits to `edge.sh` to observe how the PKCS#11 modules have to be configured. As a result, tokens available via opensc are not usable until the second time the application is started (minor issue really).

I was unable to locate an Edge policy to automatically configure the necessary PKCS libraries upon first startup. I believe Edge may have native support for p11-kit. It seems like avoidable complexity to add p11-kit to a flatpak so I have not attempted to do so.

I believe this is a completely usable and mergeable state as-is however. If this is merged in successfully I should be able to make similar changes to the Chrome flatpak.