### PR TITLE
Remove policy overrides (beta)

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -88,7 +88,6 @@ modules:
       - install -Dm 755 apply_extra.sh /app/bin/apply_extra
       - install -Dm 755 stub_sandbox.sh /app/bin/stub_sandbox
       - install -Dm 644 -t /app/etc cobalt.ini
-      - install -Dm 644 -t /app/share/flatpak-edge flatpak_policy.json
       - install -Dm 644 -t /app/share/applications com.microsoft.Edge.desktop
       - install -Dm 644 -t /app/share/metainfo com.microsoft.Edge.metainfo.xml
       - install -Dm 644 com.microsoft.Edge-256.png /app/share/icons/hicolor/256x256/apps/com.microsoft.Edge.png
@@ -118,8 +117,6 @@ modules:
         path: cobalt.ini
       - type: file
         path: apply_extra.sh
-      - type: file
-        path: flatpak_policy.json
       - type: file
         path: com.microsoft.Edge.desktop
       - type: file

--- a/edge.sh
+++ b/edge.sh
@@ -7,10 +7,6 @@ for policy_type in managed recommended enrollment; do
   policy_dir="$policy_root/$policy_type"
   mkdir -p "$policy_dir"
 
-  if [[ "$policy_type" == 'managed' ]]; then
-    ln -sf /app/share/flatpak-edge/flatpak_policy.json "$policy_dir"
-  fi
-
   if [[ -d "/run/host/$policy_root/$policy_type" ]]; then
     find "/run/host/$policy_root/$policy_type" -type f -name '*' \
       -maxdepth 1 -name '*.json' -type f \

--- a/flatpak_policy.json
+++ b/flatpak_policy.json
@@ -1,4 +1,0 @@
-{
-  "DefaultBrowserSettingEnabled": false,
-  "SmartScreenEnabled": false
-}


### PR DESCRIPTION
These were remanents of old issues with Edge and shouldn't be neccesary anymore.

Removing managed policy also fixes the lockout of certain settings, such as secure DNS

Cherry-pick of master change #388 