### PR TITLE
Update SDK & runtime to 23.08

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -1,9 +1,9 @@
 app-id: com.microsoft.Edge
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: edge
 separate-locales: false
 build-options:


### PR DESCRIPTION
A new version of the runtime was recently released, see [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0).