### PR TITLE
Update runtime and base to 23.08

### DIFF
--- a/com.microsoft.Edge.yaml
+++ b/com.microsoft.Edge.yaml
@@ -1,9 +1,9 @@
 app-id: com.microsoft.Edge
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: edge
 separate-locales: false
 build-options:


### PR DESCRIPTION
Due a Chromium.Baseapp new branch its possible update the runtime to 23.08