### PR TITLE
Fix Widevine DRM sandbox access

### DIFF
--- a/cobalt.ini
+++ b/cobalt.ini
@@ -1,6 +1,10 @@
 [Application]
 EntryPoint=/app/extra/msedge
+ConfigDir=microsoft-edge
 ExposePids=required
 
 [DefaultFeatures]
 Enabled=WebRTCPipeWireCapturer
+
+[Zypak]
+ExposeWidevine=true


### PR DESCRIPTION
## Summary

Enable Zypak's Widevine handling and provide Cobalt with the Edge profile directory.

## Problem

Netflix failed with error `D7702-1003` even though `edge://components` reported that the Widevine Content Decryption Module was installed. Edge logged the following error when loading the downloaded CDM:

```text
libwidevinecdm.so: cannot open shared object file: Operation not permitted
```

Granting broader Flatpak filesystem access did not resolve the error. Running Edge with Chromium's `--no-sandbox` option did, which isolated the failure to the Chromium/Zypak sandbox rather than the outer Flatpak filesystem sandbox.

Widevine components downloaded at runtime are stored under the browser profile directory. Zypak must explicitly expose this directory to Chromium's sandbox. Cobalt uses ConfigDir to locate the profile and, when `ExposeWidevine` is enabled, configures Zypak to expose its WidevineCdm directory.

For the stable Edge package, the profile directory is `$XDG_CONFIG_HOME/microsoft-edge`.

This follows the same Cobalt/Zypak configuration used to fix DRM handling in the Opera Flatpak: https://github.com/flathub/com.opera.Opera/issues/127.

## Testing

The equivalent change was built and tested locally from the repository's beta branch on SteamOS. The beta-specific profile directory, microsoft-edge-beta, was used for that build.

Testing included:

1. Building and installing the Flatpak with Zypak enabled.
2. Verifying the installed cobalt.ini contained the expected `ConfigDir` and `ExposeWidevine=true` settings.
3. Clearing the existing Widevine component state.
4. Launching Edge normally, without `--no-sandbox`.
5. Playing DRM-protected Netflix content successfully.
6. Closing Edge completely and repeating playback after reopening it, preserving the downloaded Widevine state.
7. Checking terminal output for widevine, cdm, and Operation not permitted.

Playback succeeded both before and after restarting Edge. The Chromium/Zypak sandbox remained enabled, and the previous libwidevinecdm.so permission error did not recur.